### PR TITLE
speed up ip2asn.FindASN

### DIFF
--- a/api/streamer/ip2asn/ip2asn.go
+++ b/api/streamer/ip2asn/ip2asn.go
@@ -123,12 +123,14 @@ func FindASN(lines []IPRange, ip netip.Addr) (IPRange, error) {
 	for start <= end {
 		mid := (start + end) / 2
 		// check if it's between StartIP and EndIP
-		if ip.Compare(lines[mid].StartIP) >= 0 && ip.Compare(lines[mid].EndIP) <= 0 {
-			return lines[mid], nil
-		} else if ip.Compare(lines[mid].StartIP) < 0 {
-			end = mid - 1
+		if ip.Compare(lines[mid].StartIP) >= 0 {
+			if ip.Compare(lines[mid].EndIP) <= 0 {
+				return lines[mid], nil
+			} else {
+				start = mid + 1
+			}
 		} else {
-			start = mid + 1
+			end = mid - 1
 		}
 	}
 	return IPRange{}, errors.New("not found")


### PR DESCRIPTION
This commit speeds up the `FindASN` function by almost 40% by not comparing the `StartIP` with the lookup IP twice.

`profile-bsearch` Benchmarks, before:
```
$ go run .
Alloc = 48 MiB
99831
number per second 6.502589154860772e+06
```

after:
```
$ go run .
Alloc = 48 MiB
99859
number per second 9.161586274914563e+06
```

I'm guessing that the compiler can't (or doesn't even attempt to) prove that `ip.Compare(ip2)` is side-effect free and it's value could be re-used. Thus whenever the IPs don't match (which is a big percentage of calls), the comparison is done twice.

By doing a slight refactor this can be avoided.

---

After having read [your very interesting blog post](https://jvns.ca/blog/2024/10/27/asn-ip-address-memory) I was curious to see how big the difference would be when removing the `EndIP`, and if it was possible to use the new `unique` [package](https://pkg.go.dev/unique) instead of the map lookup.

By removing the `EndIP` you could shave off another 18MiB:
```
$ go run . 
Alloc = 30 MiB
100000
number per second 9.221831431745583e+06
```
(baseline was 48 MiB)

I wasn't sure about the validity of such a change though - it discards some information and makes some assumptions like that the data that's being read from the `tsv` is in-order.

Using `unique` instead of the ASN pool increases memory usage by ~20MiB to 68MiB:
```
$ go run .
Alloc = 68 MiB
99862
number per second 6.557375757422143e+06
```
while not improving speed at all! I would have expected that this should give a slight speedbump as there's no lookup needed, but for some reason this doesn't seem to change anything (I'm guessing because of the extra layer of indirection, but if you have any better ideas let me know).

The fact that this needs _more_ memory can probably be explained by `unique.Handle` using a (64bit) pointer to the unique value, whereas the pool is indexed with a 32bit integer.

During these investigations, I stumbled upon this slight refactor however which improves performance drastically 😄 
